### PR TITLE
fix: add version specification for shimexe-core dependency

### DIFF
--- a/crates/shimexe-cli/Cargo.toml
+++ b/crates/shimexe-cli/Cargo.toml
@@ -16,7 +16,7 @@ name = "shimexe"
 path = "src/main.rs"
 
 [dependencies]
-shimexe-core = { path = "../shimexe-core" }
+shimexe-core = { version = "0.1.0", path = "../shimexe-core" }
 clap.workspace = true
 anyhow.workspace = true
 tracing.workspace = true


### PR DESCRIPTION
## Summary

This PR fixes the crates.io publishing error by adding version specification for the `shimexe-core` dependency in the `shimexe` CLI package.

## Problem

The `release-plz` tool was failing to publish the `shimexe` package with the following error:

```
ERROR failed to release package
Caused by:
    failed to publish shimexe: error: all dependencies must have a version specified when publishing.
    dependency `shimexe-core` does not specify a version
```

This occurred because the `shimexe-core` dependency in `crates/shimexe-cli/Cargo.toml` only specified a `path` but no `version`, which is required for publishing to crates.io.

## Solution

### 🔧 Dependency Configuration Fix
- **Added version specification**: Updated `shimexe-core` dependency to include `version = "0.1.0"`
- **Maintained path dependency**: Kept the local `path` specification for development
- **Publishing compatibility**: Now meets crates.io requirements for dependency versioning

### 📁 Changes Made

**File**: `crates/shimexe-cli/Cargo.toml`
```diff
- shimexe-core = { path = "../shimexe-core" }
+ shimexe-core = { version = "0.1.0", path = "../shimexe-core" }
```

## Testing

- ✅ `cargo check` passes successfully
- ✅ `cargo publish --dry-run --allow-dirty -p shimexe` completes without errors
- ✅ Package verification and compilation successful
- ✅ All dependencies resolved correctly

## Impact

- **Enables crates.io publishing**: `shimexe` package can now be published successfully
- **Fixes release-plz workflow**: Automated releases will work without manual intervention
- **Maintains development workflow**: Local development continues to work with path dependencies
- **Follows Rust best practices**: Proper dependency versioning for published crates

## Verification

Before:
```bash
$ release-plz release
# ERROR: dependency `shimexe-core` does not specify a version
```

After:
```bash
$ cargo publish --dry-run -p shimexe
# ✅ Successfully packages and verifies shimexe v0.1.0
# ✅ All dependencies properly resolved
```

Signed-off-by: longhao <hal.long@outlook.com>