### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.2.1](https://github.com/loonghao/shimexe/compare/v0.2.0...v0.2.1) - 2025-06-17
+
+### Fixed
+
+- resolve clippy warnings and implement Default trait for ConfigCache
+
 ## [0.2.0](https://github.com/loonghao/shimexe/compare/v0.1.4...v0.2.0) - 2025-06-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,7 +1454,7 @@ dependencies = [
 
 [[package]]
 name = "shimexe"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "shimexe-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "shimexe"
 path = "src/main.rs"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Hal <hal.long@outlook.com>"]
 license = "MIT"
@@ -69,7 +69,7 @@ async-trait = "0.1"
 tempfile = "3.8"
 
 [dependencies]
-shimexe-core = { version = "0.2.0", path = "crates/shimexe-core" }
+shimexe-core = { version = "0.2.1", path = "crates/shimexe-core" }
 clap.workspace = true
 anyhow.workspace = true
 tracing.workspace = true

--- a/crates/shimexe-core/CHANGELOG.md
+++ b/crates/shimexe-core/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.2.1](https://github.com/loonghao/shimexe/compare/shimexe-core-v0.2.0...shimexe-core-v0.2.1) - 2025-06-17
+
+### Added
+
+- optimize performance and fix workflow
+
+### Fixed
+
+- resolve clippy warnings and implement Default trait for ConfigCache
+
 ## [0.2.0](https://github.com/loonghao/shimexe/compare/shimexe-core-v0.1.4...shimexe-core-v0.2.0) - 2025-06-17
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `shimexe-core`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `shimexe`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `shimexe-core`

<blockquote>

## [0.2.1](https://github.com/loonghao/shimexe/compare/shimexe-core-v0.2.0...shimexe-core-v0.2.1) - 2025-06-17

### Added

- optimize performance and fix workflow

### Fixed

- resolve clippy warnings and implement Default trait for ConfigCache
</blockquote>

## `shimexe`

<blockquote>

## [0.2.1](https://github.com/loonghao/shimexe/compare/v0.2.0...v0.2.1) - 2025-06-17

### Fixed

- resolve clippy warnings and implement Default trait for ConfigCache
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).