### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.0](https://github.com/loonghao/shimexe/compare/v0.2.1...v0.3.0) - 2025-06-17
+
+### Added
+
+- add comprehensive archive support and package management
+
+### Fixed
+
+- *(deps)* update rust crate zip to v4
+- remove needless borrow in archive path handling
+
+### Other
+
+- *(deps)* update softprops/action-gh-release action to v2
+
 ## [0.2.1](https://github.com/loonghao/shimexe/compare/v0.2.0...v0.2.1) - 2025-06-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "shimexe"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "shimexe-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "shimexe"
 path = "src/main.rs"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["Hal <hal.long@outlook.com>"]
 license = "MIT"
@@ -69,7 +69,7 @@ async-trait = "0.1"
 tempfile = "3.8"
 
 [dependencies]
-shimexe-core = { version = "0.2.1", path = "crates/shimexe-core" }
+shimexe-core = { version = "0.3.0", path = "crates/shimexe-core" }
 clap.workspace = true
 anyhow.workspace = true
 tracing.workspace = true

--- a/crates/shimexe-core/CHANGELOG.md
+++ b/crates/shimexe-core/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.0](https://github.com/loonghao/shimexe/compare/shimexe-core-v0.2.1...shimexe-core-v0.3.0) - 2025-06-17
+
+### Added
+
+- add comprehensive archive support and package management
+
+### Fixed
+
+- *(deps)* update rust crate zip to v4
+
 ## [0.2.1](https://github.com/loonghao/shimexe/compare/shimexe-core-v0.2.0...shimexe-core-v0.2.1) - 2025-06-17
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `shimexe-core`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)
* `shimexe`: 0.2.1 -> 0.3.0

### ⚠ `shimexe-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ShimCore.source_type in /tmp/.tmpZWUkf8/shimexe/crates/shimexe-core/src/config.rs:154
  field ShimCore.extracted_executables in /tmp/.tmpZWUkf8/shimexe/crates/shimexe-core/src/config.rs:157
  field ShimCore.source_type in /tmp/.tmpZWUkf8/shimexe/crates/shimexe-core/src/config.rs:154
  field ShimCore.extracted_executables in /tmp/.tmpZWUkf8/shimexe/crates/shimexe-core/src/config.rs:157
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `shimexe-core`

<blockquote>

## [0.3.0](https://github.com/loonghao/shimexe/compare/shimexe-core-v0.2.1...shimexe-core-v0.3.0) - 2025-06-17

### Added

- add comprehensive archive support and package management

### Fixed

- *(deps)* update rust crate zip to v4
</blockquote>

## `shimexe`

<blockquote>

## [0.3.0](https://github.com/loonghao/shimexe/compare/v0.2.1...v0.3.0) - 2025-06-17

### Added

- add comprehensive archive support and package management

### Fixed

- *(deps)* update rust crate zip to v4
- remove needless borrow in archive path handling

### Other

- *(deps)* update softprops/action-gh-release action to v2
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).