### PR TITLE
chore: release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.3](https://github.com/loonghao/shimexe/compare/v0.3.2...v0.3.3) - 2025-06-18
+
+### Added
+
+- add comprehensive vx integration example
+- add high-level ShimManager API and update Chinese README
+- enhance README with logo and improve vx integration
+
+### Fixed
+
+- resolve clippy warnings and compilation errors
+- correct PATH usage and improve user guidance
+- add retry logic and fallback for GitHub API rate limits
+
 ## [0.3.2](https://github.com/loonghao/shimexe/compare/v0.3.1...v0.3.2) - 2025-06-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "shimexe"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "shimexe-core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "shimexe"
 path = "src/main.rs"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = ["Hal <hal.long@outlook.com>"]
 license = "MIT"
@@ -69,7 +69,7 @@ async-trait = "0.1"
 tempfile = "3.8"
 
 [dependencies]
-shimexe-core = { version = "0.3.2", path = "crates/shimexe-core" }
+shimexe-core = { version = "0.3.3", path = "crates/shimexe-core" }
 clap.workspace = true
 anyhow.workspace = true
 tracing.workspace = true

--- a/crates/shimexe-core/CHANGELOG.md
+++ b/crates/shimexe-core/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.3](https://github.com/loonghao/shimexe/compare/shimexe-core-v0.3.2...shimexe-core-v0.3.3) - 2025-06-18
+
+### Added
+
+- add high-level ShimManager API and update Chinese README
+
+### Fixed
+
+- resolve clippy warnings and compilation errors
+
 ## [0.3.0](https://github.com/loonghao/shimexe/compare/shimexe-core-v0.2.1...shimexe-core-v0.3.0) - 2025-06-17
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `shimexe-core`: 0.3.2 -> 0.3.3 (✓ API compatible changes)
* `shimexe`: 0.3.2 -> 0.3.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `shimexe-core`

<blockquote>

## [0.3.3](https://github.com/loonghao/shimexe/compare/shimexe-core-v0.3.2...shimexe-core-v0.3.3) - 2025-06-18

### Added

- add high-level ShimManager API and update Chinese README

### Fixed

- resolve clippy warnings and compilation errors
</blockquote>

## `shimexe`

<blockquote>

## [0.3.3](https://github.com/loonghao/shimexe/compare/v0.3.2...v0.3.3) - 2025-06-18

### Added

- add comprehensive vx integration example
- add high-level ShimManager API and update Chinese README
- enhance README with logo and improve vx integration

### Fixed

- resolve clippy warnings and compilation errors
- correct PATH usage and improve user guidance
- add retry logic and fallback for GitHub API rate limits
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).