### PR TITLE
chore: release v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.4](https://github.com/loonghao/shimexe/compare/v0.3.3...v0.3.4) - 2025-06-18
+
+### Fixed
+
+- support both v* and shimexe-v* tag formats in install scripts
+- improve version detection and release changelog formatting
+- configure release-plz to show only current version changelog in releases
+- resolve version detection issues in install scripts and update Scoop manifest
+
 ## [0.3.3](https://github.com/loonghao/shimexe/compare/v0.3.2...v0.3.3) - 2025-06-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "shimexe"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "shimexe-core"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "shimexe"
 path = "src/main.rs"
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 authors = ["Hal <hal.long@outlook.com>"]
 license = "MIT"
@@ -69,7 +69,7 @@ async-trait = "0.1"
 tempfile = "3.8"
 
 [dependencies]
-shimexe-core = { version = "0.3.3", path = "crates/shimexe-core" }
+shimexe-core = { version = "0.3.4", path = "crates/shimexe-core" }
 clap.workspace = true
 anyhow.workspace = true
 tracing.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `shimexe-core`: 0.3.3 -> 0.3.4
* `shimexe`: 0.3.3 -> 0.3.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `shimexe-core`

<blockquote>

## [0.3.3](https://github.com/loonghao/shimexe/compare/shimexe-core-v0.3.2...shimexe-core-v0.3.3) - 2025-06-18

### Added

- add high-level ShimManager API and update Chinese README

### Fixed

- resolve clippy warnings and compilation errors
</blockquote>

## `shimexe`

<blockquote>

## [0.3.4](https://github.com/loonghao/shimexe/compare/v0.3.3...v0.3.4) - 2025-06-18

### Fixed

- support both v* and shimexe-v* tag formats in install scripts
- improve version detection and release changelog formatting
- configure release-plz to show only current version changelog in releases
- resolve version detection issues in install scripts and update Scoop manifest
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).