### PR TITLE
chore: release v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.5](https://github.com/loonghao/shimexe/compare/v0.3.4...v0.3.5) - 2025-06-19
+
+### Other
+
+- *(deps)* update rust crate thiserror to v2
+
 ## [0.3.4](https://github.com/loonghao/shimexe/compare/v0.3.3...v0.3.4) - 2025-06-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "shimexe"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "shimexe-core"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "shimexe"
 path = "src/main.rs"
 
 [workspace.package]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 authors = ["Hal <hal.long@outlook.com>"]
 license = "MIT"
@@ -69,7 +69,7 @@ async-trait = "0.1"
 tempfile = "3.8"
 
 [dependencies]
-shimexe-core = { version = "0.3.4", path = "crates/shimexe-core" }
+shimexe-core = { version = "0.3.5", path = "crates/shimexe-core" }
 clap.workspace = true
 anyhow.workspace = true
 tracing.workspace = true

--- a/crates/shimexe-core/CHANGELOG.md
+++ b/crates/shimexe-core/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.5](https://github.com/loonghao/shimexe/compare/shimexe-core-v0.3.4...shimexe-core-v0.3.5) - 2025-06-19
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.3.3](https://github.com/loonghao/shimexe/compare/shimexe-core-v0.3.2...shimexe-core-v0.3.3) - 2025-06-18
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `shimexe-core`: 0.3.4 -> 0.3.5 (✓ API compatible changes)
* `shimexe`: 0.3.4 -> 0.3.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `shimexe-core`

<blockquote>

## [0.3.5](https://github.com/loonghao/shimexe/compare/shimexe-core-v0.3.4...shimexe-core-v0.3.5) - 2025-06-19

### Other

- update Cargo.toml dependencies
</blockquote>

## `shimexe`

<blockquote>

## [0.3.5](https://github.com/loonghao/shimexe/compare/v0.3.4...v0.3.5) - 2025-06-19

### Other

- *(deps)* update rust crate thiserror to v2
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).