### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.0](https://github.com/loonghao/shimexe/compare/shimexe-v0.4.0...shimexe-v0.5.0) - 2025-07-05
+
+### Added
+
+- disable clippy uninlined_format_args lint
+- upgrade turbo-cdn to 0.4.3 and improve verbose logging control
+
+### Fixed
+
+- resolve clippy and rustdoc warnings for CI compatibility
+
+### Other
+
+- *(deps)* update crazy-max/ghaction-chocolatey action to v3.4.0
+
 ## [0.4.0](https://github.com/loonghao/shimexe/compare/v0.3.5...v0.4.0) - 2025-06-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "shimexe"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2363,7 +2363,7 @@ dependencies = [
 
 [[package]]
 name = "shimexe-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = "shimexe"
 path = "src/main.rs"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Hal <hal.long@outlook.com>"]
 license = "MIT"
@@ -72,7 +72,7 @@ async-trait = "0.1"
 tempfile = "3.8"
 
 [dependencies]
-shimexe-core = { version = "0.4.0", path = "crates/shimexe-core" }
+shimexe-core = { version = "0.5.0", path = "crates/shimexe-core" }
 clap.workspace = true
 anyhow.workspace = true
 tracing.workspace = true

--- a/crates/shimexe-core/CHANGELOG.md
+++ b/crates/shimexe-core/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.0](https://github.com/loonghao/shimexe/compare/shimexe-core-v0.4.0...shimexe-core-v0.5.0) - 2025-07-05
+
+### Added
+
+- disable clippy uninlined_format_args lint
+- upgrade turbo-cdn to 0.4.3 and improve verbose logging control
+
+### Fixed
+
+- resolve remaining clippy uninlined format args warnings
+- resolve clippy and rustdoc warnings for CI compatibility
+- adjust performance test timeouts for Windows environment
+
 ## [0.4.0](https://github.com/loonghao/shimexe/compare/shimexe-core-v0.3.5...shimexe-core-v0.4.0) - 2025-06-23
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `shimexe-core`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `shimexe`: 0.4.0 -> 0.5.0

### ⚠ `shimexe-core` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_method_missing.ron

Failed in:
  Downloader::get_optimal_url, previously in file /tmp/.tmpfDLmet/shimexe-core/src/downloader.rs:146
  Downloader::parse_url, previously in file /tmp/.tmpfDLmet/shimexe-core/src/downloader.rs:154
  Downloader::get_optimal_url, previously in file /tmp/.tmpfDLmet/shimexe-core/src/downloader.rs:146
  Downloader::parse_url, previously in file /tmp/.tmpfDLmet/shimexe-core/src/downloader.rs:154
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `shimexe-core`

<blockquote>

## [0.5.0](https://github.com/loonghao/shimexe/compare/shimexe-core-v0.4.0...shimexe-core-v0.5.0) - 2025-07-05

### Added

- disable clippy uninlined_format_args lint
- upgrade turbo-cdn to 0.4.3 and improve verbose logging control

### Fixed

- resolve remaining clippy uninlined format args warnings
- resolve clippy and rustdoc warnings for CI compatibility
- adjust performance test timeouts for Windows environment
</blockquote>

## `shimexe`

<blockquote>

## [0.5.0](https://github.com/loonghao/shimexe/compare/shimexe-v0.4.0...shimexe-v0.5.0) - 2025-07-05

### Added

- disable clippy uninlined_format_args lint
- upgrade turbo-cdn to 0.4.3 and improve verbose logging control

### Fixed

- resolve clippy and rustdoc warnings for CI compatibility

### Other

- *(deps)* update crazy-max/ghaction-chocolatey action to v3.4.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).