### PR TITLE
fix: optimize release-plz config for mixed workspace

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -11,16 +11,25 @@
 #
 # This approach leverages release-plz's strengths (version management, changelog, crates.io)
 # while using the specialized upload-rust-binary-action for cross-platform builds.
+#
+# Note: This is a mixed workspace where the root contains both workspace config and a package.
+# The shimexe package is at the root, and shimexe-core is in crates/shimexe-core.
 
 [workspace]
-# Enable automatic changelog generation
+# Global defaults for all packages in the workspace
 changelog_update = true
-# Disable GitHub releases at workspace level (handled by package level)
+# Disable GitHub releases by default (only shimexe main package needs releases)
 git_release_enable = false
-# Enable automatic tag creation (triggers release.yml)
-git_tag_enable = true
-# Enable processing for releases
+# Disable git tagging by default (only shimexe main package needs tags)
+git_tag_enable = false
+# Enable release processing for all packages
 release = true
+# Release behavior - only release when merging release PR
+release_always = false
+# Semver checking enabled for all packages
+semver_check = true
+# Update dependencies across workspace
+dependencies_update = true
 
 # Changelog configuration
 [changelog]
@@ -34,23 +43,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 """
 
-# Package-specific configuration for shimexe
+# Package-specific configuration for shimexe (main CLI executable package at root)
 [[package]]
 name = "shimexe"
-# Enable changelog updates
+# Explicit path for root package in mixed workspace
+path = "."
+# Enable changelog updates for main package
 changelog_update = true
-# Enable GitHub releases (release-plz creates draft, release.yml adds binaries and publishes)
+# Enable GitHub releases (needed for executable distribution and package managers)
 git_release_enable = true
+# Enable git tagging for main package (triggers release.yml workflow)
+git_tag_enable = true
 # Enable processing for releases
 release = true
-# Standard tag format (triggers release workflows) - with 'v' prefix to trigger release.yml
+# Standard tag format (v1.0.0) - triggers release.yml for cross-platform binaries
 git_tag_name = "v{{version}}"
 # Allow major version bumps for breaking changes
 allow_dirty = false
 # Ensure proper semantic versioning
 semver_check = true
-# Create published releases (upload-rust-binary-action will add binaries)
+# Create published releases (release.yml will add cross-platform binaries)
 git_release_draft = false
+# Enable crates.io publishing for main package
+publish = true
+# Changelog path for main package
+changelog_path = "CHANGELOG.md"
 # Custom release body template
 git_release_body = """
 ## 🚀 What's Changed
@@ -84,3 +101,25 @@ scoop install shimexe
 
 **Full Changelog**: https://github.com/loonghao/shimexe/compare/{{previous_tag}}...{{version}}
 """
+
+# Package-specific configuration for shimexe-core (library package)
+[[package]]
+name = "shimexe-core"
+# Explicit path for core package in workspace
+path = "crates/shimexe-core"
+# Disable GitHub releases for core package (library only needs crates.io)
+git_release_enable = false
+# Disable git tagging for core package (no need for separate tags)
+git_tag_enable = false
+# Enable crates.io publishing for library
+publish = true
+# Enable changelog updates for core package
+changelog_update = true
+# Enable processing for releases
+release = true
+# Ensure proper semantic versioning
+semver_check = true
+# Changelog path for core package
+changelog_path = "crates/shimexe-core/CHANGELOG.md"
+# Allow dirty working directory for core package
+allow_dirty = false


### PR DESCRIPTION
## 🔧 Problem Solved

Fixed release-plz configuration issues in mixed workspace setup where both executable and library packages exist.

## 📋 Changes Made

### 🎯 shimexe (Main CLI Package)
- ✅ **GitHub Release**: Enabled - for executable distribution
- ✅ **Git Tagging**: Enabled - triggers release.yml workflow  
- ✅ **Crates.io**: Enabled - publish CLI tool
- 🏷️ **Tag Format**: `v{{version}}` (e.g., v0.5.3)

### 📚 shimexe-core (Library Package)
- ❌ **GitHub Release**: Disabled - library doesn't need GitHub releases
- ❌ **Git Tagging**: Disabled - no separate tags needed
- ✅ **Crates.io**: Enabled - publish library

### 🏗️ Workspace Configuration
- **Fixed workspace defaults** to prevent unnecessary releases
- **Explicit path configuration** for mixed workspace structure
- **Proper package separation** between executable and library

## 🔄 Release Workflow

1. **release-plz** creates PR with version updates and changelog
2. After PR merge, **release-plz** publishes to crates.io and creates GitHub release (main package only)
3. GitHub release triggers **release.yml** workflow for cross-platform binaries
4. **release.yml** uploads binaries and triggers package manager publishing

## ✅ Benefits

- **Cleaner releases**: Only main package creates GitHub releases
- **Proper separation**: Library vs executable package handling
- **Reduced noise**: No unnecessary tags or releases for library
- **Better automation**: Clear trigger chain for binary distribution

## 🧪 Testing

- ✅ TOML syntax validation
- ✅ Cargo workspace structure verification
- ✅ Clippy checks passed
- ✅ Project compilation successful

---

**Ready for merge** - This fixes the release-plz configuration issues and establishes proper release workflow for the mixed workspace setup.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author