### PR TITLE
chore: release v0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.5](https://github.com/loonghao/shimexe/compare/shimexe-v0.5.4...shimexe-v0.5.5) - 2025-07-06
+
+### Fixed
+
+- completely disable codecov status checks to prevent CI failures
+
 ## [0.5.4](https://github.com/loonghao/shimexe/compare/shimexe-v0.5.3...shimexe-v0.5.4) - 2025-07-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,7 +2345,7 @@ dependencies = [
 
 [[package]]
 name = "shimexe"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -2363,7 +2363,7 @@ dependencies = [
 
 [[package]]
 name = "shimexe-core"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = "shimexe"
 path = "src/main.rs"
 
 [workspace.package]
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 authors = ["Hal <hal.long@outlook.com>"]
 license = "MIT"
@@ -72,7 +72,7 @@ async-trait = "0.1"
 tempfile = "3.8"
 
 [dependencies]
-shimexe-core = { version = "0.5.4", path = "crates/shimexe-core" }
+shimexe-core = { version = "0.5.5", path = "crates/shimexe-core" }
 clap.workspace = true
 anyhow.workspace = true
 tracing.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `shimexe-core`: 0.5.4 -> 0.5.5
* `shimexe`: 0.5.4 -> 0.5.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `shimexe-core`

<blockquote>

## [0.5.2](https://github.com/loonghao/shimexe/compare/shimexe-core-v0.5.1...shimexe-core-v0.5.2) - 2025-07-06

### Added

- enhance package publishing and fix env config
</blockquote>

## `shimexe`

<blockquote>

## [0.5.5](https://github.com/loonghao/shimexe/compare/shimexe-v0.5.4...shimexe-v0.5.5) - 2025-07-06

### Fixed

- completely disable codecov status checks to prevent CI failures
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).