### PR TITLE
fix: resolve release-please Rust workspace configuration

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,74 +1,22 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "bootstrap-sha": "HEAD",
-  "release-type": "rust",
+  "bootstrap-sha": "cea8746",
   "include-v-in-tag": true,
+  "plugins": [
+    {
+      "type": "cargo-workspace",
+      "merge": false
+    }
+  ],
   "packages": {
-    ".": {
-      "package-name": "shimexe",
-      "component": "shimexe",
-      "changelog-path": "CHANGELOG.md",
-      "release-type": "rust",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
-      "extra-files": [
-        {
-          "type": "generic",
-          "path": "pkg/scoop/shimexe.json",
-          "replacements": [
-            {
-              "type": "regex",
-              "search": "\"version\": \"[^\"]*\"",
-              "replace": "\"version\": \"{{version}}\""
-            },
-            {
-              "type": "regex",
-              "search": "v[0-9]+\\.[0-9]+\\.[0-9]+",
-              "replace": "v{{version}}"
-            },
-            {
-              "type": "regex",
-              "search": "shimexe-[0-9]+\\.[0-9]+\\.[0-9]+",
-              "replace": "shimexe-{{version}}"
-            }
-          ]
-        },
-        {
-          "type": "generic",
-          "path": "pkg/homebrew/shimexe.rb",
-          "replacements": [
-            {
-              "type": "regex",
-              "search": "version \"[^\"]*\"",
-              "replace": "version \"{{version}}\""
-            },
-            {
-              "type": "regex",
-              "search": "shimexe-[0-9]+\\.[0-9]+\\.[0-9]+",
-              "replace": "shimexe-{{version}}"
-            }
-          ]
-        },
-        {
-          "type": "generic",
-          "path": "pkg/chocolatey/shimexe.nuspec.template",
-          "replacements": [
-            {
-              "type": "regex",
-              "search": "{{VERSION}}",
-              "replace": "{{version}}"
-            }
-          ]
-        }
-      ]
-    },
     "crates/shimexe-core": {
       "package-name": "shimexe-core",
       "component": "shimexe-core",
       "changelog-path": "crates/shimexe-core/CHANGELOG.md",
       "release-type": "rust",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "skip-github-release": false
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## 🔧 Fix Release-Please Rust Workspace Configuration

This PR resolves the persistent `value at path package.version is not tagged` error by implementing proper Rust workspace configuration based on release-please documentation.

### 🐛 Root Cause Analysis

After researching release-please documentation, the issue was:

1. **Root directory still configured**: The config contained a `"."` package entry that release-please was trying to manage
2. **Missing cargo-workspace plugin**: Rust workspaces require the `cargo-workspace` plugin for proper handling
3. **Invalid bootstrap-sha**: Was set to `"HEAD"` instead of a specific commit SHA
4. **Workspace auto-detection**: release-please was auto-detecting the workspace and trying to manage all packages

### 🛠️ Solution Implementation

**Based on official documentation:**
- [Manifest Releaser - cargo-workspace](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#cargo-workspace)
- Rust workspaces require manifest driven release and `cargo-workspace` plugin

**Key Changes:**

1. **✅ Removed root directory package** - Completely eliminated `"."` configuration
2. **✅ Added cargo-workspace plugin** - With `merge: false` to prevent automatic merging
3. **✅ Fixed bootstrap-sha** - Set to specific commit `cea8746` instead of `"HEAD"`
4. **✅ Simplified configuration** - Only `shimexe-core` crate managed by release-please
5. **✅ Proper separation** - Root workspace package handled by GitHub releases workflow

### 📝 Configuration Diff

**Before:**
```json
{
  "bootstrap-sha": "HEAD",
  "release-type": "rust",
  "packages": {
    ".": { /* root package config */ },
    "crates/shimexe-core": { /* core config */ }
  }
}
```

**After:**
```json
{
  "bootstrap-sha": "cea8746",
  "plugins": [
    {
      "type": "cargo-workspace",
      "merge": false
    }
  ],
  "packages": {
    "crates/shimexe-core": { /* only core config */ }
  }
}
```

### ✅ Expected Results

- ✅ No more `"value at path package.version is not tagged"` errors
- ✅ Release-please only processes `shimexe-core` crate
- ✅ Proper Rust workspace handling with cargo-workspace plugin
- ✅ Clean separation between crate releases and binary releases
- ✅ Reliable CI/CD pipeline

### 🧪 Testing

This can be tested by:
1. Merging this PR
2. Triggering the release workflow
3. Verifying release-please runs without errors
4. Confirming only shimexe-core is processed

---

**Type**: Critical Bug Fix  
**Impact**: High (fixes broken release automation)  
**Breaking Changes**: None  
**Documentation**: Based on official release-please docs