### PR TITLE
fix: resolve cargo-workspace plugin version validation error

### DIFF
--- a/crates/shimexe-core/Cargo.toml
+++ b/crates/shimexe-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shimexe-core"
-version.workspace = true
+version = "0.5.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## 🔧 Fix Cargo-Workspace Plugin Version Validation

This PR resolves the new error that appeared after implementing the cargo-workspace plugin:

```
release-please failed: cargo-workspace (loonghao/shimexe): package manifest at crates/shimexe-core/Cargo.toml has an invalid [package.version]
```

### 🐛 Problem Analysis

The `cargo-workspace` plugin requires **explicit version numbers** in package Cargo.toml files and cannot handle workspace version inheritance (`version.workspace = true`).

**Root Cause:**
- `shimexe-core/Cargo.toml` was using `version.workspace = true`
- The cargo-workspace plugin needs to read and modify version numbers directly
- Workspace inheritance prevents the plugin from accessing the actual version value

### 🛠️ Solution

**Change in `crates/shimexe-core/Cargo.toml`:**

```diff
 [package]
 name = "shimexe-core"
-version.workspace = true
+version = "0.5.6"
 edition.workspace = true
```

### ✅ Why This Fix Works

1. **✅ Explicit version access**: cargo-workspace plugin can now read the version directly
2. **✅ Version consistency**: Matches the current workspace version (0.5.6)
3. **✅ Plugin compatibility**: Allows cargo-workspace to function properly
4. **✅ Release-please integration**: Enables proper version bumping and dependency management

### 📝 Technical Details

The cargo-workspace plugin needs to:
- Read current version numbers from Cargo.toml files
- Update version numbers when dependencies change
- Manage dependency relationships between workspace crates

Workspace inheritance (`version.workspace = true`) abstracts the version away, making it inaccessible to the plugin's version management logic.

### 🧪 Testing

After this change:
1. The cargo-workspace plugin should be able to read the version
2. Release-please should run without the version validation error
3. Future version bumps will work correctly

### 🔄 Future Maintenance

When the workspace version is updated, the shimexe-core version should be updated accordingly to maintain consistency. The cargo-workspace plugin will handle this automatically during releases.

---

**Type**: Bug Fix  
**Impact**: Medium (fixes release automation)  
**Breaking Changes**: None  
**Dependencies**: Requires cargo-workspace plugin to function