### PR TITLE
fix: resolve root package version validation for cargo-workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "shimexe"
-version.workspace = true
+version = "0.5.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## 🔧 Fix Root Package Version Validation

This PR resolves the latest cargo-workspace plugin error:

```
Error: release-please failed: cargo-workspace (loonghao/shimexe): package manifest at Cargo.toml has an invalid [package.version]
```

### 🐛 Problem Analysis

Even after fixing the `shimexe-core` version, the cargo-workspace plugin is **still discovering and validating the root package** during workspace analysis.

**From the logs:**
```
✅ looking for candidate with path: .
❯ Fetching Cargo.toml from branch main
Error: cargo-workspace (loonghao/shimexe): package manifest at Cargo.toml has an invalid [package.version]
```

**Root Cause:**
- The cargo-workspace plugin performs **workspace-wide discovery**
- It finds and validates **ALL** Cargo.toml files in the workspace
- Root package was still using `version.workspace = true`
- Plugin requires explicit versions in all discovered packages

### 🛠️ Solution

**Change in root `Cargo.toml`:**

```diff
 [package]
 name = "shimexe"
-version.workspace = true
+version = "0.5.6"
 edition.workspace = true
```

### ✅ Why This Fixes The Issue

1. **✅ Workspace Discovery**: cargo-workspace plugin scans entire workspace
2. **✅ Validation Requirement**: All discovered packages need explicit versions
3. **✅ Root Package Inclusion**: Even unconfigured packages are validated
4. **✅ Version Consistency**: Maintains 0.5.6 across all packages

### 📝 Technical Background

The cargo-workspace plugin operates in two phases:

1. **Discovery Phase**: Finds all Cargo.toml files in workspace
2. **Validation Phase**: Validates version format in each discovered package

Even though our `release-please-config.json` only configures `crates/shimexe-core`, the plugin still discovers and validates the root package during workspace analysis.

### 🔍 Log Analysis

From the error logs, we can see the plugin's behavior:

```
✅ Building list of all packages
❯ Fetching Cargo.toml from branch main          # Root workspace
❯ finding files by glob: crates/shimexe-core    # Configured package
✅ looking for candidate with path: crates/shimexe-core
❯ Fetching crates/shimexe-core/Cargo.toml
✅ looking for candidate with path: .           # Root package discovery!
❯ Fetching Cargo.toml from branch main
Error: invalid [package.version]                   # Validation failure
```

### 🧪 Expected Results

After this fix:
1. ✅ cargo-workspace plugin can validate all discovered packages
2. ✅ No more version validation errors
3. ✅ Release-please workflow runs successfully
4. ✅ Proper workspace dependency management

### 🔄 Future Considerations

Both root and shimexe-core packages now have explicit versions. The cargo-workspace plugin will manage version synchronization during releases, ensuring consistency across the workspace.

---

**Type**: Critical Bug Fix  
**Impact**: High (fixes broken release automation)  
**Breaking Changes**: None  
**Scope**: Workspace configuration