### PR TITLE
ci: add release-please dry-run validation on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,9 +149,15 @@ jobs:
       - name: Validate release-please configuration (dry-run)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_URL: ${{ github.repository }}
+          TARGET_BRANCH: ${{ github.base_ref }}
         run: |
-          release-please manifest \
-            --token=${GITHUB_TOKEN} \
+          # Default to main if TARGET_BRANCH is empty (shouldn't happen on PRs)
+          TARGET_BRANCH="${TARGET_BRANCH:-main}"
+          release-please release-pr \
+            --token="${GITHUB_TOKEN}" \
+            --repo-url="${REPO_URL}" \
+            --target-branch="${TARGET_BRANCH}" \
             --config-file=release-please-config.json \
             --manifest-file=.release-please-manifest.json \
             --dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,3 +127,32 @@ jobs:
           flags: unittests
           name: codecov-umbrella
 
+
+  # Release-please dry-run validation (PR only)
+  release_please_check:
+    name: Release Please Dry Run
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js (for release-please CLI)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install release-please CLI
+        run: |
+          npm install -g release-please
+
+      - name: Validate release-please configuration (dry-run)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          release-please manifest \
+            --token=${GITHUB_TOKEN} \
+            --config-file=release-please-config.json \
+            --manifest-file=.release-please-manifest.json \
+            --dry-run
+


### PR DESCRIPTION
Add a Release Please configuration validation step to CI for pull requests.

What this does
- Installs release-please CLI
- Runs `release-please manifest --dry-run` with our config/manifest to catch config errors early during PRs

Why
- Ensures release configuration correctness at PR stage, avoiding surprises post-merge

Notes
- This check runs only on pull_request events
- No release/tag creation, no side effects

Signed-off-by: Hal <hal.long@outlook.com>