### PR TITLE
fix(ci): ensure root autobump by removing cargo-workspace plugin

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,12 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "cea8746",
   "include-v-in-tag": true,
-  "plugins": [
-    {
-      "type": "cargo-workspace",
-      "merge": false
-    }
-  ],
+
   "packages": {
     ".": {
       "package-name": "shimexe",


### PR DESCRIPTION
Problem
- release-please reported no in-scope releases and skipped autobump for root, and only considered `shimexe-core`.

Fix
- Remove `cargo-workspace` plugin and rely solely on explicit `packages` mapping (root `.` and `crates/shimexe-core`).
- This keeps root crate bump/tag generation deterministic and prevents plugin-side merging logic from hiding root bump when no user-facing commits are detected under core.

Files changed
- release-please-config.json

Notes
- Manifest already includes root entry: `.release-please-manifest.json` shows root `0.5.8`.
- This PR does not alter release behavior except ensuring the root is considered independently.

Signed-off-by: Hal <hal.long@outlook.com>