### PR TITLE
ci(release-please): unblock auto-bump by enforcing PR title pattern and cleaning pending labels

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,28 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Cleanup stale 'autorelease: pending' labels on merged PRs
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const q = `repo:${owner}/${repo} label:\"autorelease: pending\" is:pr is:merged`;
+            const resp = await github.rest.search.issuesAndPullRequests({ q });
+            for (const pr of resp.data.items || []) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  name: 'autorelease: pending',
+                });
+                core.info(`Removed 'autorelease: pending' from #${pr.number}`);
+              } catch (e) {
+                core.warning(`Label cleanup failed for #${pr.number}: ${e.message}`);
+              }
+            }
       - uses: googleapis/release-please-action@v4
         id: release
         with:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "cea8746",
   "include-v-in-tag": true,
+  "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
   "packages": {
     ".": {
       "package-name": "shimexe",


### PR DESCRIPTION
This PR fixes release-please autobump not triggering after merge.

Changes:
- Add pull-request-title-pattern to release-please-config.json to satisfy required placeholders and avoid parsing errors
- Add a cleanup step in release-please.yml to remove stale `autorelease: pending` labels on merged PRs, preventing stuck state that blocks tagging

Why:
- We saw errors like `pullRequestTitlePattern miss the part of '${scope}' / '${component}' / '${version}'` and `There are untagged, merged release PRs outstanding - aborting`.
- Commit parsing also complained about unexpected tokens in merge commit titles. Enforcing the PR title pattern ensures release PRs are parseable.

After merge:
- Pushing to main should let release-please create/merge the release PR normally.
- When the release PR is merged, tags and releases should be created and downstream workflows (assets, package publish) will trigger as expected.

Notes:
- No behavior changes to code; CI-only adjustments.

Signed-off-by: Hal <13111745+loonghao@users.noreply.github.com>

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author