### PR TITLE
fix(release): unify workspace versioning and reduce duplicate release PRs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ async-trait = "0.1"
 tempfile = "3.8"
 
 [dependencies]
-shimexe-core = { version = "0.5.10", path = "crates/shimexe-core" }
+shimexe-core = { path = "crates/shimexe-core" }
 clap.workspace = true
 anyhow.workspace = true
 tracing.workspace = true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "bootstrap-sha": "cea8746",
+
   "include-v-in-tag": true,
-  "pull-request-title-pattern": "chore${scope}: release${component} ${version}",
+
   "packages": {
     ".": {
       "package-name": "shimexe",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,7 @@
       "release-type": "rust",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "include-component-in-tag": true
+      "include-component-in-tag": false
     },
     "crates/shimexe-core": {
       "package-name": "shimexe-core",
@@ -21,7 +21,7 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "skip-github-release": true,
-      "include-component-in-tag": true
+      "include-component-in-tag": false
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
This PR fixes two issues observed after merging:

1) Version resolution failed in CI:
   error: failed to select a version for the requirement `shimexe-core = "^0.5.10"`
   cause: candidate versions found which didn't match: 0.5.9

   Fix: In workspace root Cargo.toml, depend on shimexe-core by path only to avoid mismatches between crate publish version and local workspace state.

2) Multiple release PRs / duplicate tagging noise:
   Fix: In release-please-config.json, set include-component-in-tag=false for both packages to keep a standard tag `vX.Y.Z` and avoid component-specific duplication.

These changes should stabilize autobump and unify version calculation across the workspace.

Signed-off-by: Hal <13111745+loonghao@users.noreply.github.com>