### PR TITLE
ci(release-please): align with docs (cargo-workspace plugin, grouped PR)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,8 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-
   "include-v-in-tag": true,
-
+  "separate-pull-requests": false,
+  "group-pull-request-title-pattern": "chore: release ${branch}",
+  "plugins": ["cargo-workspace"],
   "packages": {
     ".": {
       "package-name": "shimexe",


### PR DESCRIPTION
Align release-please configuration with upstream docs for Rust workspaces:

- Enable `cargo-workspace` plugin to calculate versions consistently across crates
- Group releases with `separate-pull-requests=false` to avoid duplicate release PRs
- Set `group-pull-request-title-pattern` to keep default `chore: release main`

Note: We keep `include-v-in-tag=true` and `include-component-in-tag=false` to produce standard `vX.Y.Z` tags and avoid per-component tag noise.

This should address:
- Mismatched versions between shimexe and shimexe-core
- Multiple release PRs being opened
- PR title format consistency with release-please expectations

Signed-off-by: Hal <13111745+loonghao@users.noreply.github.com>

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author