### PR TITLE
ci(release-please): anchor bootstrap-sha to v0.5.9

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "0bd991ec53ad70792425dd2d8139f01dfdd8296d",
   "include-v-in-tag": true,
   "separate-pull-requests": false,
   "group-pull-request-title-pattern": "chore: release ${branch}",


### PR DESCRIPTION
Anchor release-please to the last known good release tag to dedupe changelog and stop repeated release PR creation.

- Set `bootstrap-sha` to commit of tag `v0.5.9` (0bd991ec53ad70792425dd2d8139f01dfdd8296d)
- No functional code changes

After merge: trigger Release Please once. You should see a single `chore: release main` PR with clean notes from v0.5.9 onward.

Signed-off-by: Hal <13111745+loonghao@users.noreply.github.com>