### PR TITLE
ci(release-please): use manifest command to ensure tagging after merge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,6 +40,8 @@ jobs:
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          command: manifest
+          default-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
Switch release-please action to `command: manifest` so that tagging is handled correctly after release PR merge.

- Keeps current config (cargo-workspace + single root package)
- Should change nothing for the release PR creation, but ensures that tags are created when the release PR is merged (per release-please docs for manifest-driven repos)

After merge: merge the next `chore: release main` and confirm tag + release assets/release publish workflows fire.

Signed-off-by: Hal <13111745+loonghao@users.noreply.github.com>