### PR TITLE
ci(release-please): use default PR title (remove group pattern)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,6 @@
   "bootstrap-sha": "0bd991ec53ad70792425dd2d8139f01dfdd8296d",
   "include-v-in-tag": true,
   "separate-pull-requests": false,
-  "group-pull-request-title-pattern": "chore: release ${branch}",
   "plugins": ["cargo-workspace"],
   "packages": {
     ".": {


### PR DESCRIPTION
Remove group-pull-request-title-pattern to let Release Please use default title behavior.

This helps avoid duplicate/ambiguous grouped titles and aligns with manifest mode so tags and GitHub Releases get created after merging the release PR.

Signed-off-by: Hal <13111745+loonghao@users.noreply.github.com>