### PR TITLE
ci(release-please): fix action inputs for v4 (remove command/default-branch)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,8 +40,6 @@ jobs:
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          command: manifest
-          default-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
Remove unsupported inputs `command` and `default-branch` from release-please action v4.

- v4 infers manifest mode from `manifest-file` presence; no need for `command`
- Default branch is resolved from repo; not needed here

This should clear the warning and keep tagging + GitHub Release behavior after merging the release PR.

Signed-off-by: Hal <13111745+loonghao@users.noreply.github.com>